### PR TITLE
namescope package name to innobridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shared",
+  "name": "@innobridge/shared",
   "version": "0.0.1",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",


### PR DESCRIPTION
This pull request updates the package name in the `package.json` file to use a scoped name, which helps clarify ownership and makes it easier to manage shared code across the organization.