### PR TITLE
add address model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as languages from '@/constants/languages';
+import * as address from '@/models/address';
 
 export { 
-    languages 
+    languages,
+    address
 };

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -1,0 +1,19 @@
+type LatLng = {
+    lat: number;
+    lng: number;
+};
+
+interface Address {
+  placeId: string;           // place_id (for Google Places)
+  name?: string;             // place name / establishment name (use instead of formatted address)
+  city?: string;             // locality / postal_town
+  province?: string;         // full name British Columbia
+  country?: string;          // ISO alpha-2 (e.g. "CA") - preferred
+  postalCode?: string;       // postal_code
+  location?: LatLng;         // lat/lng
+};
+
+export {
+    Address,
+    LatLng
+};


### PR DESCRIPTION
This pull request updates the shared package to expose a new `address` model and its types, making it easier for other parts of the organization to use standardized address data. The most important changes are grouped below:

**Public API and Package Versioning**

* Updated the package version in `package.json` from `0.0.1` to `0.0.2` to reflect the new addition to the public API.
* Added the `address` export to `src/index.ts`, making the new address model available to consumers of the package.

**New Address Model**

* Introduced a new `Address` interface and supporting `LatLng` type in `src/models/address.ts`, defining a standardized structure for address data including fields for place ID, name, city, province, country, postal code, and location coordinates.