### PR TITLE
add unit number to address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -4,13 +4,14 @@ type LatLng = {
 };
 
 interface Address {
-  placeId: string;           // place_id (for Google Places)
-  name?: string;             // place name / establishment name (use instead of formatted address)
-  city?: string;             // locality / postal_town
-  province?: string;         // full name British Columbia
-  country?: string;          // ISO alpha-2 (e.g. "CA") - preferred
-  postalCode?: string;       // postal_code
-  location?: LatLng;         // lat/lng
+    placeId: string;           // place_id (for Google Places)
+    name?: string;             // place name / establishment name (use instead of formatted address)
+    unitNumber?: string;       // Unit, suite or apartment (subpremise)
+    city?: string;             // locality / postal_town
+    province?: string;         // full name British Columbia
+    country?: string;          // ISO alpha-2 (e.g. "CA") - preferred
+    postalCode?: string;       // postal_code
+    location?: LatLng;         // lat/lng
 };
 
 export {


### PR DESCRIPTION
This pull request updates the shared package version and enhances the `Address` model to better support subpremise information. The most important changes are outlined below.

**Package Version Update**

* Updated the version in `package.json` from `0.0.2` to `0.0.3` to reflect new changes and improvements.

**Model Enhancement**

* Added an optional `unitNumber` field to the `Address` interface in `src/models/address.ts` to capture unit, suite, or apartment numbers (subpremise), improving address granularity.