### PR TITLE
add id to address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -4,6 +4,7 @@ type LatLng = {
 };
 
 interface Address {
+    id: string;            // internal ID
     placeId: string;           // place_id (for Google Places)
     name?: string;             // place name / establishment name (use instead of formatted address)
     unitNumber?: string;       // Unit, suite or apartment (subpremise)


### PR DESCRIPTION
This pull request updates the shared package version and adds an internal identifier to the `Address` model to support more robust address handling. 

Version update:

* Bumped the version of `@innobridge/shared` in `package.json` from `0.0.3` to `0.0.4` to reflect the latest changes.

Model enhancement:

* Added an `id` field to the `Address` interface in `src/models/address.ts` to store an internal identifier for addresses.