### PR TITLE
make address.userid non optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -18,7 +18,7 @@ interface BaseAddress {
 // Backend storage representation of an address
 interface Address extends BaseAddress {
     id: string;                // internal ID
-    userId?: string;           // user ID (if associated with a user)
+    userId: string;           // user ID (if associated with a user)
 };
 
 export {


### PR DESCRIPTION
This pull request includes a version bump for the shared package and a change to the `Address` model to require a `userId` for all addresses. The most important changes are:

Versioning:

* Updated the version in `package.json` from `0.0.5` to `0.0.6` to reflect the new release.

Model update:

* Changed the `userId` property in the `Address` interface (`src/models/address.ts`) from optional to required, ensuring all address records are associated with a user.