### PR TITLE
add provider model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 import * as languages from '@/constants/languages';
 import * as address from '@/models/address';
+import * as email from '@/models/email';
+import * as user from '@/models/user';
+import * as provider from '@/models/provider';
 
 export { 
     languages,
-    address
+    address,
+    email,
+    user,
+    provider
 };

--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -10,5 +10,5 @@ export interface Provider extends User {
   serviceRadius: number;
   canVisitClientHome: boolean;
   virtualHelpOffered: boolean;
-  businessName?: string | null;
+  businessName?: string;
 }

--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -1,0 +1,14 @@
+import { User } from "./user";
+
+// Provider extends User with additional fields specific to service providers.
+// Fields:
+// - serviceRadius (required): number
+// - canVisitClientHome (required): boolean
+// - virtualHelpOffered (required): boolean
+// - businessName (optional): string
+export interface Provider extends User {
+  serviceRadius: number;
+  canVisitClientHome: boolean;
+  virtualHelpOffered: boolean;
+  businessName?: string | null;
+}


### PR DESCRIPTION
This pull request updates the shared package to version 0.0.8 and expands its exports to include new models for `email`, `user`, and `provider`. The most significant change is the introduction of the `Provider` interface, which extends the existing `User` model with fields relevant to service providers.

**Model additions and updates:**

* Added new `Provider` interface in `src/models/provider.ts`, extending `User` with fields for service radius, client home visits, virtual help, and optional business name.
* Added new exports for `email`, `user`, and `provider` models in `src/index.ts`, making them available for consumers of the shared package.

**Version update:**

* Bumped package version from 0.0.7 to 0.0.8 in `package.json` to reflect the new additions.