### PR TITLE
change providerID to providerId

### DIFF
--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -2,13 +2,13 @@ import { User } from "@/models/user";
 
 // Provider extends User with additional fields specific to service providers.
 // Fields:
-// - providerID (replaces userId): string
+// - providerId (replaces userId): string
 // - serviceRadius (required): number
 // - canVisitClientHome (required): boolean
 // - virtualHelpOffered (required): boolean
 // - businessName (optional): string
 export interface Provider extends Omit<User, 'userId'> {
-  providerID: string;
+  providerId: string;
   serviceRadius: number;
   canVisitClientHome: boolean;
   virtualHelpOffered: boolean;


### PR DESCRIPTION
This pull request makes a small change to the `Provider` interface in `src/models/provider.ts`, updating the field name from `providerID` to `providerId` for consistency with naming conventions.