### PR TITLE
change username to providername, and ad Provider Address and Email Address

### DIFF
--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -1,3 +1,5 @@
+import { B } from "vitest/dist/chunks/worker.d.CHGSOG0s.js";
+
 type LatLng = {
     lat: number;
     lng: number;
@@ -21,8 +23,14 @@ interface Address extends BaseAddress {
     userId: string;           // user ID (if associated with a user)
 };
 
+interface ProviderAddress extends BaseAddress {
+    id: string;                // internal ID
+    providerId: string;        // provider ID (if associated with a provider)
+};
+
 export {
     BaseAddress,
     Address,
+    ProviderAddress,
     LatLng
 };

--- a/src/models/email.ts
+++ b/src/models/email.ts
@@ -4,6 +4,11 @@ interface EmailAddress {
   emailAddress: string;
 };
 
+interface ProviderEmailAddress extends Omit<EmailAddress, 'userId'> {
+  providerId?: string;
+}
+
 export {
-    EmailAddress
+    EmailAddress,
+    ProviderEmailAddress
 };

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,16 +1,16 @@
-import { EmailAddress } from "@/models/email";
-import { Address } from "@/models/address";
+import { ProviderEmailAddress } from "@/models/email";
+import { ProviderAddress } from "@/models/address";
 
 interface User {
   id: string;
-  username: string | null;
+  providername: string | null;
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
-  emailAddresses: EmailAddress[];
+  emailAddresses: ProviderEmailAddress[];
   phoneNumber: string | null;
   languages: string[];
-  address?: Address;
+  address?: ProviderAddress;
   passwordEnabled: boolean;
   twoFactorEnabled: boolean;
   backupCodeEnabled: boolean;


### PR DESCRIPTION
This pull request updates the user, address, and email models to introduce provider-specific types and refactor references to use these new types. The changes primarily support associating users, addresses, and email addresses with external providers, improving data modeling and extensibility.

### Model Refactoring for Provider Support

* Added new `ProviderAddress` and `ProviderEmailAddress` interfaces to support provider-specific data, and updated exports in `src/models/address.ts` and `src/models/email.ts` accordingly. [[1]](diffhunk://#diff-bf40b161c64f4af4341d36931f7662c908f461eca310ff0d0bec008bf3092cb2R26-R34) [[2]](diffhunk://#diff-cf512e1d677bf38cef00a74b5fbfb2b9742b70d995839728c2b507eedd0dfddbR7-R13)
* Refactored the `User` interface in `src/models/user.ts` to use `ProviderAddress` and `ProviderEmailAddress` instead of the previous types, and changed `username` to `providername` for provider association.

### Dependency Updates

* Updated imports in `src/models/user.ts` to use the new provider-specific types.
* Added an import from `vitest/dist/chunks/worker.d.CHGSOG0s.js` in `src/models/address.ts`, though its purpose is unclear and may need review.