### PR TITLE
fix fields in users and provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -1,4 +1,6 @@
 import { User } from "@/models/user";
+import { ProviderEmailAddress } from "@/models/email";
+import { ProviderAddress } from "@/models/address";
 
 // Provider extends User with additional fields specific to service providers.
 // Fields:
@@ -7,8 +9,16 @@ import { User } from "@/models/user";
 // - canVisitClientHome (required): boolean
 // - virtualHelpOffered (required): boolean
 // - businessName (optional): string
-export interface Provider extends Omit<User, 'userId'> {
+export interface Provider extends Omit<User, 
+  'userId' 
+  | 'username'
+  | 'emailAddresses'
+  | 'address'
+  > {
   providerId: string;
+  providerName: string | null;
+  emailAddresses: ProviderEmailAddress[];
+  address?: ProviderAddress;
   serviceRadius: number;
   canVisitClientHome: boolean;
   virtualHelpOffered: boolean;

--- a/src/models/provider.ts
+++ b/src/models/provider.ts
@@ -10,12 +10,10 @@ import { ProviderAddress } from "@/models/address";
 // - virtualHelpOffered (required): boolean
 // - businessName (optional): string
 export interface Provider extends Omit<User, 
-  'userId' 
-  | 'username'
+  'username'
   | 'emailAddresses'
   | 'address'
   > {
-  providerId: string;
   providerName: string | null;
   emailAddresses: ProviderEmailAddress[];
   address?: ProviderAddress;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,16 +1,16 @@
-import { ProviderEmailAddress } from "@/models/email";
-import { ProviderAddress } from "@/models/address";
+import { EmailAddress } from "@/models/email";
+import { Address } from "@/models/address";
 
 interface User {
   id: string;
-  providername: string | null;
+  username: string | null;
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
-  emailAddresses: ProviderEmailAddress[];
+  emailAddresses: EmailAddress[];
   phoneNumber: string | null;
   languages: string[];
-  address?: ProviderAddress;
+  address?: Address;
   passwordEnabled: boolean;
   twoFactorEnabled: boolean;
   backupCodeEnabled: boolean;


### PR DESCRIPTION
This pull request refactors the `Provider` and `User` models to clarify their structure and relationships, especially regarding personal and provider-specific fields. The changes help separate provider-specific data from general user data, making the models easier to maintain and extend.

**Model structure improvements:**

* In `src/models/provider.ts`, the `Provider` interface now omits additional fields from `User` (`username`, `emailAddresses`, `address`) and introduces provider-specific versions: `providerName`, `emailAddresses` as `ProviderEmailAddress[]`, and `address` as `ProviderAddress`.
* The file now imports `ProviderEmailAddress` and `ProviderAddress` to support the provider-specific fields.

**User model cleanup:**

* In `src/models/user.ts`, the `User` interface replaces provider-specific types with general ones: `emailAddresses` is now `EmailAddress[]`, and `address` is now `Address`. Also, the field `providername` is renamed to `username` for clarity.