### PR TITLE
export eventMapper; add event model and mapping utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/shared",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "InnoBridge",
       "devDependencies": {
         "@types/node": "^22.15.29",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/shared",
-      "version": "0.0.7",
+      "version": "0.1.0",
       "license": "InnoBridge",
       "devDependencies": {
         "@types/node": "^22.15.29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Share code across the organization.",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,17 @@
 import * as languages from '@/constants/languages';
 import * as address from '@/models/address';
 import * as email from '@/models/email';
+import * as event from '@/models/event';
 import * as user from '@/models/user';
 import * as provider from '@/models/provider';
+import * as eventMapper from '@/utils/event_mapper';
 
 export { 
     languages,
     address,
     email,
+    event,
     user,
-    provider
+    provider,
+    eventMapper,
 };

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,0 +1,11 @@
+type EventType = 'user.created' | 'user.updated' | 'user.deleted';
+type Event = {
+  data: Record<string, any>;
+  object: 'event';
+  type: EventType;
+};
+
+export { 
+    Event, 
+    EventType
+};

--- a/src/utils/event_mapper.ts
+++ b/src/utils/event_mapper.ts
@@ -1,0 +1,210 @@
+import { Event } from '@/models/event';
+import { User } from '@/models/user';
+import { Provider } from '@/models/provider';
+import { EmailAddress, ProviderEmailAddress } from '@/models/email';
+import { BaseAddress, Address, ProviderAddress } from '@/models/address';
+import { randomUUID } from 'crypto';
+
+
+const mapEventToUser = (event: Event): User => {
+    const data = event.data;
+
+    const createdAt = data.created_at ? Number(data.created_at) : Date.now();
+    const updatedAt = data.updated_at ? Number(data.updated_at) : Date.now();
+
+    const emailAddress = mapEventToEmailAddresses(event);
+    const address = mapEventToAddress(event);
+    const phoneNumber = mapEventToPhoneNumber(event);
+    const languages = mapEventToLanguages(event);
+
+    return {
+        id: data.id as string,
+        username: data.username as string | null,
+        firstName: data.first_name as string | null,
+        lastName: data.last_name as string | null,
+        imageUrl: data.image_url as string,
+        emailAddresses: emailAddress,
+        phoneNumber: phoneNumber,
+        languages: languages,
+        address: address,
+        passwordEnabled: Boolean(data.password_enabled),
+        twoFactorEnabled: Boolean(data.two_factor_enabled),
+        backupCodeEnabled: Boolean(data.backup_code_enabled),
+        createdAt: createdAt,
+        updatedAt: updatedAt
+    } as User;
+};
+
+const mapEventToEmailAddresses = (event: Event): EmailAddress[] => {
+    const data = event.data;
+    const emailAddresses = data.email_addresses as Record<string, string>[];
+    return emailAddresses.map((emailAddress) => {
+        return {
+            id: emailAddress.id,
+            userId: data.id as string,
+            emailAddress: emailAddress.email_address
+        } as EmailAddress;
+    });
+};
+
+
+const mapEventToAddress = (event: Event): Address | undefined => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return undefined;
+
+    const baseAddress = (unsafeMetadata as Record<string, any>).address as BaseAddress | undefined;
+    if (baseAddress) {
+        return {
+            id: randomUUID(),
+            userId: String(event.data.id),
+            ...baseAddress
+        } as Address;
+    }
+    return undefined;
+};
+
+const mapEventToProvider = (event: Event): Provider => {
+    const data = event.data;
+    
+    const createdAt = data.created_at ? Number(data.created_at) : Date.now();
+    const updatedAt = data.updated_at ? Number(data.updated_at) : Date.now();
+
+    const providerEmailAddress = mapEventToProviderEmailAddresses(event);
+    const address = mapEventToProviderAddress(event);
+    const phoneNumber = mapEventToPhoneNumber(event);
+    const languages = mapEventToLanguages(event);
+    const serviceRadius = mapEventToServiceRadius(event);
+    const canVisitClientHome = mapEventToCanVisitClientHome(event);
+    const virtualHelpOffered = mapEventToVirtualHelpOffered(event);
+    const businessName = mapEventToBusinessName(event);
+
+    return {
+        id: data.id as string,
+        providerName: data.username as string || null,
+        firstName: data.first_name as string || null,
+        lastName: data.last_name as string || null,
+        imageUrl: data.image_url as string,
+        emailAddresses: providerEmailAddress,
+        phoneNumber: phoneNumber,
+        languages: languages,
+        address: address,
+        passwordEnabled: Boolean(data.password_enabled),
+        twoFactorEnabled: Boolean(data.two_factor_enabled),
+        backupCodeEnabled: Boolean(data.backup_code_enabled),
+        serviceRadius: serviceRadius,
+        canVisitClientHome: canVisitClientHome,
+        virtualHelpOffered: virtualHelpOffered,
+        businessName: businessName,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+    }
+};
+
+const mapEventToProviderEmailAddresses = (event: Event): ProviderEmailAddress[] => {
+    const data = event.data;
+    const providerEmailAddresses = data.email_addresses as Record<string, string>[];
+    return providerEmailAddresses.map(ea => ({
+        id: ea.id,
+        providerId: data.id,
+        emailAddress: ea.email_address
+    } as ProviderEmailAddress));
+};
+
+const mapEventToPhoneNumber = (event: Event): string | null => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return null;
+
+    const phoneNumberData = (unsafeMetadata as Record<string, any>).phoneNumber;
+    return String(phoneNumberData ?? null);
+};
+
+const mapEventToLanguages = (event: Event): string[] => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return [];
+
+    const raw = (unsafeMetadata as Record<string, any>).languages;
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map(String);
+    if (typeof raw === 'string') {
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed.map(String) : [String(parsed)];
+        } catch {
+            // fallback: accept comma-separated string like "english,mandarin"
+            const trimmed = raw.trim();
+            return trimmed.length ? trimmed.split(',').map(s => s.trim()).filter(Boolean) : [];
+        }
+    }
+    return [];
+};
+
+const mapEventToProviderAddress = (event: Event): ProviderAddress | undefined => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return undefined;
+
+    const baseAddress = (unsafeMetadata as Record<string, any>).address as BaseAddress | undefined;
+    if (baseAddress) {
+        return {
+            id: randomUUID(),
+            providerId: String(event.data.id),
+            ...baseAddress
+        } as ProviderAddress;
+    }
+    return undefined;
+};
+
+const mapEventToServiceRadius = (event: Event): number => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return 0;
+
+    const serviceRadiusData = (unsafeMetadata as Record<string, any>).serviceRadius;
+    if (!serviceRadiusData || isNaN(Number(serviceRadiusData))) {
+        throw new Error('Invalid serviceRadius value');
+    }
+    const serviceRadius = Number(serviceRadiusData);
+    if (serviceRadius < 0) {
+        throw new Error('serviceRadius cannot be negative');
+    }
+    return serviceRadius;
+};
+
+const mapEventToCanVisitClientHome = (event: Event): boolean => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return false;
+
+    const canVisitClientHomeData = (unsafeMetadata as Record<string, any>).canVisitClientHome;
+    return Boolean(canVisitClientHomeData);
+};
+
+const mapEventToVirtualHelpOffered = (event: Event): boolean => {
+    const unsafeMetadata = event.data.unsafe_metadata;
+    if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return false;
+
+    const virtualHelpOfferedData = (unsafeMetadata as Record<string, any>).virtualHelpOffered;
+    return Boolean(virtualHelpOfferedData);
+};
+
+const mapEventToBusinessName = (event: Event): string | undefined => {
+  const unsafeMetadata = event.data.unsafe_metadata;
+  if (!unsafeMetadata || typeof unsafeMetadata !== 'object' || Array.isArray(unsafeMetadata)) return undefined;
+
+  const businessNameData = (unsafeMetadata as Record<string, any>).businessName;
+  if (!businessNameData || typeof businessNameData !== 'string') return undefined;
+  const trimmed = businessNameData.trim();
+  return trimmed.length ? trimmed : undefined;
+};
+
+export {
+    mapEventToUser,
+    mapEventToEmailAddresses,
+    mapEventToAddress,
+    mapEventToProvider,
+    mapEventToProviderEmailAddresses,
+    mapEventToPhoneNumber,
+    mapEventToLanguages,
+    mapEventToProviderAddress,
+    mapEventToServiceRadius,
+    mapEventToCanVisitClientHome,
+    mapEventToVirtualHelpOffered,
+    mapEventToBusinessName
+}


### PR DESCRIPTION
This pull request introduces a new event-driven mapping system to the shared package, allowing you to convert event objects into user and provider models, along with their associated data. It adds a new event model, a comprehensive set of mapping utilities, and updates the package exports to make these features available. The package version is also incremented to reflect these significant changes.

**Event Model and Mapping Utilities**

* Added a new `Event` type and `EventType` union in `src/models/event.ts` to represent user-related events in a structured way.
* Implemented `src/utils/event_mapper.ts`, a utility module with functions to map event data into `User`, `Provider`, email addresses, addresses, and other related fields, handling various edge cases and data formats.

**Package Exports**

* Updated `src/index.ts` to export the new `event` model and all event mapping utilities, making them accessible to consumers of the package.

**Version Update**

* Bumped the package version from `0.0.11` to `0.1.1` in `package.json` to indicate the introduction of new features and breaking changes.